### PR TITLE
Implementar registro de ADM_IPS como requisito para crear IPS

### DIFF
--- a/EPS/backend/src/main/java/com/eps/apexeps/configurations/SecurityConfiguration.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/configurations/SecurityConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
+import org.springframework.web.cors.CorsConfigurationSource;
 import com.eps.apexeps.models.auth.ERol;
 
 import lombok.RequiredArgsConstructor;
@@ -31,10 +31,13 @@ public class SecurityConfiguration {
     /** Proveedor de autenticación */
     private final AuthenticationProvider authProvider;
 
+    /** Fuente de configuración CORS */
+    private final CorsConfigurationSource corsConfigurationSource;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-            .cors().and()
+            .cors(cors -> cors.configurationSource(corsConfigurationSource))
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                     // Rutas de prueba de rol.

--- a/EPS/backend/src/main/java/com/eps/apexeps/configurations/WebConfigartion.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/configurations/WebConfigartion.java
@@ -1,10 +1,10 @@
 package com.eps.apexeps.configurations;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.lang.NonNull;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 /**
   * Clase de configuración para habilitar CORS en la aplicación.
@@ -12,22 +12,21 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   */
 @Configuration
 public class WebConfigartion {
-    
+
     /**
      * Configuración de CORS para permitir solicitudes desde el frontend.
-     * @return WebMvcConfigurer
+     * @return CorsConfigurationSource que define las políticas de CORS.
      */
-	@Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(@NonNull CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-            }
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            var configuration = new org.springframework.web.cors.CorsConfiguration();
+            configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+            configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+            configuration.setAllowedHeaders(List.of("*"));
+            configuration.setAllowCredentials(true);
+
+            return configuration;
         };
     }
 

--- a/EPS/backend/src/main/java/com/eps/apexeps/controllers/IpsController.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/controllers/IpsController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.eps.apexeps.models.DTOs.ServicioEnIpsDTO;
 import com.eps.apexeps.models.entity.Ips;
+import com.eps.apexeps.models.entity.users.AdmIps;
 import com.eps.apexeps.models.DTOs.response.IpsEntradaLista;
 import com.eps.apexeps.models.DTOs.response.IpsConServicios;
 import com.eps.apexeps.models.DTOs.response.IpsLista;
@@ -89,14 +90,13 @@ public class IpsController {
     }
 
     @PostMapping
-    public ResponseEntity<Ips> save(@RequestBody Ips ips) throws IOException {
+    public ResponseEntity<?> save(@RequestBody AdmIps admIps) throws IOException {
         try {
-            return ResponseEntity.ok(ipsService.save(ips));
+            return ResponseEntity.ok(ipsService.create(admIps));
         } catch (IOException e) {
+            RuntimeException re = new RuntimeException("Error al guardar la IPS: " + e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(null);
-            // TODO: throw new RuntimeException("Error al guardar la IPS: " +
-            // e.getMessage(), e);
+                    .body(re);
         }
     }
 

--- a/EPS/backend/src/main/java/com/eps/apexeps/services/IpsService.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/services/IpsService.java
@@ -9,27 +9,33 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.eps.apexeps.models.DTOs.ServicioEnIpsDTO;
 import com.eps.apexeps.models.entity.Ips;
+import com.eps.apexeps.models.entity.users.AdmIps;
+import com.eps.apexeps.repositories.AdmIpsRespository;
 import com.eps.apexeps.repositories.IpsRepository;
 import com.eps.apexeps.models.DTOs.response.IpsConServicios;
 
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 
 /**
  *
  * @author Alexander
  */
 @Service
+@RequiredArgsConstructor
 public class IpsService {
 
-    @Autowired
-    private IpsRepository ipsRepository;
+    /** Repositorio para manejar las operaciones CRUD de AdmIps */
+    private final AdmIpsRespository admIpsRespository;
+
+    /** Repositorio para manejar las operaciones CRUD de Ips */
+    private final IpsRepository ipsRepository;
 
     public List<Ips> findAll() {
         return ipsRepository.findAll();
@@ -71,22 +77,23 @@ public class IpsService {
 
 
     /**
-     * Guarda una nueva IPS en la base de datos.
+     * Crea una nueva IPS y administrador en la base de datos.
      * Intenta guardar la imagen de la IPS en el sistema de archivos.
-     * @param ips La IPS a guardar
-     * @return La IPS guardada
+     * @param adm El administrador con la información de la IPS.
+     * @return El administrador creado con la IPS asociada.
      * @throws IOException Si ocurre un error al guardar la imagen
      */
     @Transactional
-    public Ips save(Ips ips) throws IOException {
+    public AdmIps create(AdmIps adm) throws IOException {
 
         // Primero intenta guardar la ips actualizada.
-        Ips ipsNueva = ipsRepository.save(ips);
+        Ips ipsNueva = ipsRepository.save(adm.getIps());
         // Luego intenta guardar la imagen de la ips en el sistema de archivos.
-        ipsNueva.setImagen(ips.getImagen());
+        ipsNueva.setImagen(adm.getIps().getImagen());
         ipsNueva.saveImage();
 
-        return ipsNueva;
+        // Finalmente intenta guardar el administrador de la IPS.
+        return admIpsRespository.save(adm);
     }
 
     public void deleteById(Integer id) {

--- a/EPS/backend/src/main/java/com/eps/apexeps/services/MedicoService.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/services/MedicoService.java
@@ -32,9 +32,6 @@ public class MedicoService {
     /** Repositorio de consultorios para acceder a la base de datos. */
     private final ConsultorioRepository consultorioRepository;
 
-    /** Repositorio de Trabaja para acceder a la base de datos. */
-    private final TrabajaRepository trabajaRepository;
-
     /** Repositorio de ServicioMedico para acceder a la base de datos. */
     private final ServicioMedicoRepository servicioMedicoRepository;
 

--- a/EPS/backend/src/main/java/com/eps/apexeps/services/TrabajaService.java
+++ b/EPS/backend/src/main/java/com/eps/apexeps/services/TrabajaService.java
@@ -10,7 +10,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/EPS/frontend/src/pages/EPS/IPS/IPSFormulario.jsx
+++ b/EPS/frontend/src/pages/EPS/IPS/IPSFormulario.jsx
@@ -5,17 +5,26 @@ import {
   TextField,
   Chip,
   Button,
+  InputAdornment,
+  IconButton,
 } from '@mui/material';
 import { listaServiciosMedicosPorIPS } from '@/../../src/services/serviciosMedicosService';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 const IPSFormulario = ({
   initialData = {},
   onSubmit,
   onCancel,
+  isNew = false,
 }) => {
   const [formData, setFormData] = useState(initialData || {});
   const [serviciosMedicos, setServiciosMedicos] = useState([]);
   const fileInputRef = useRef();
+
+  // Para mostrar y oculatar el contenido de la contraseña.
+  const [showPassword, setShowPassword] = useState(false);
+  const handleClickShowPassword = () => setShowPassword(!showPassword);
+  const handleMouseDownPassword = () => setShowPassword(!showPassword);
 
   useEffect(() => {
     const fetchServiciosDeLaIPS = async () => {
@@ -76,7 +85,7 @@ const IPSFormulario = ({
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
           <Box
             component="img"
-            src={`data:image/png;base64,${formData.imagen}`}
+            src={formData && formData.imagen ? `data:image/png;base64,${formData.imagen}` : null}
             alt="Foto"
             sx={{ width: 150, height: 125, borderRadius: 2, objectFit: 'cover' }}
           />
@@ -98,6 +107,48 @@ const IPSFormulario = ({
           <TextField label="Nombre" value={formData.nombre || ''} onChange={handleChange('nombre')} />
           <TextField label="Dirección" value={formData.direccion || ''} onChange={handleChange('direccion')} />
           <TextField label="Teléfono" value={formData.telefono || ''} onChange={handleChange('telefono')} />
+
+          {/* Campos para creación */}
+          {isNew && (
+            <>
+              <TextField
+                label="Nombre Administrador"
+                value={formData.nombreAdministrador || ''}
+                onChange={handleChange('nombreAdministrador')}
+              />
+              <TextField
+                label="Teléfono Administrador"
+                value={formData.telefonoAdministrador || ''}
+                onChange={handleChange('telefonoAdministrador')}
+              />
+              <TextField
+                label="Correo Administrador"
+                value={formData.emailAdministrador || ''}
+                onChange={handleChange('emailAdministrador')}
+              />
+              <TextField
+                label='Password Administrador'
+                type={showPassword ? "text" : "password"}
+                value={formData.passwordAdministrador || ''}
+                onChange={handleChange('passwordAdministrador')}
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label="toggle password visibility"
+                          onClick={handleClickShowPassword}
+                          onMouseDown={handleMouseDownPassword}
+                        >
+                          {showPassword ? <Visibility /> : <VisibilityOff />}
+                        </IconButton>
+                      </InputAdornment>
+                    )
+                  }
+                }}
+              />
+            </>
+          )}
         </Box>
 
         {/* Botones */}

--- a/EPS/frontend/src/pages/EPS/IPS/IPSLista.jsx
+++ b/EPS/frontend/src/pages/EPS/IPS/IPSLista.jsx
@@ -58,14 +58,20 @@ const IPSLista = () => {
   const handleSubmitIPS = async (ips) => {
     try {
       const datosEnviar = {
-        nombre: ips.nombre,
-        direccion: ips.direccion,
-        telefono: ips.telefono,
-        activo: true,
-        imagen: ips.imagen,
-        admEps: {
-          email: subEmail,
-        },
+        email: ips.emailAdministrador,
+        nombre: ips.nombreAdministrador,
+        telefono: ips.telefonoAdministrador,
+        password: ips.passwordAdministrador,
+        ips: {
+          nombre: ips.nombre,
+          direccion: ips.direccion,
+          telefono: ips.telefono,
+          activo: true,
+          imagen: ips.imagen,
+          admEps: {
+            email: subEmail,
+          }
+        }
       };
 
       if (editandoIPS && editandoIPS.id)
@@ -169,6 +175,7 @@ const IPSLista = () => {
 
       {mostrarFormulario && !editandoIPS && (
         <IPSFormulario
+          isNew
           onSubmit={handleSubmitIPS}
           onCancel={handleOcultarFormulario}
         />

--- a/EPS/frontend/src/pages/IPS/Medico/MedicoFormulario.jsx
+++ b/EPS/frontend/src/pages/IPS/Medico/MedicoFormulario.jsx
@@ -170,18 +170,20 @@ const MedicoFormulario = ({
             type={showPassword ? "text" : "password"}
             value={formData.password || ''}
             onChange={handleChange('password')}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={handleClickShowPassword}
-                    onMouseDown={handleMouseDownPassword}
-                  >
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              )
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="toggle password visibility"
+                      onClick={handleClickShowPassword}
+                      onMouseDown={handleMouseDownPassword}
+                    >
+                      {showPassword ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                  </InputAdornment>
+                )
+              }
             }}
           />
           <TextField label="DNI" value={formData.dni || ''} onChange={handleChange('dni')} />


### PR DESCRIPTION
1. Modificando el POST de IPS en el back para requerir un objeto AdmIps, creando la IPS y el AdmIps en el proceso.
2. Incluyendo campos de creación de AdmIps en formulario de IPS cuando es una IPS nueva.

Adicionalmente, limpia todas las cosas sin usar en el back y *actualiza el método para configurar CORS a una versión no deprecada.*